### PR TITLE
First release of the X-NUCLEO-53L0A1 library

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,23 @@
+COPYRIGHT(c) 2017 STMicroelectronics
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+  1. Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+  2. Redistributions in binary form must reproduce the above copyright notice,
+     this list of conditions and the following disclaimer in the documentation
+     and/or other materials provided with the distribution.
+  3. Neither the name of STMicroelectronics nor the names of its contributors
+     may be used to endorse or promote products derived from this software
+     without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,48 @@
 # X-NUCLEO-53L0A1
+
 Arduino library to support the X-NUCLEO-53L0A1 based on VL53L0X Time-of-Flight and gesture-detection sensor
+This sensor uses I2C to communicate. An I2C instance is required to access to the sensor.
+The APIs provide simple distance measure, single swipe gesture detection,
+directional (left/right) swipe gesture detection and single tap gesture detection.
+
+## Examples
+
+There are 4 examples with the  X-NUCLEO-53L0A1 library.
+* X_NUCLEO_53L0A1_HelloWorld: This example code is to show how to get proximity
+  values of the onboard VL53L0X sensor and eventually of the two satellites
+
+* X_NUCLEO_53L0A1_Gesture_DirSwipe: This example code is to show how to combine the
+  proximity values of the two VL53L0X sensor satellites together with the gesture library
+  in order to detect a directional swipe gesture.
+
+* X_NUCLEO_53L0A1_Gesture_Swipe1: This example code is to show how to combine the
+  proximity value of the onboard VL53L0X sensor together with the gesture library
+  in order to detect a simple swipe gesture without considering the direction.
+
+* X_NUCLEO_53L0A1_Gesture_Tap1: This example code is to show how to combine the
+  proximity value of the onboard VL53L0X sensor together with the gesture
+  library in order to detect a simple tap gesture.
+
+##Dependencies
+
+This package requires the following Arduino libraries:
+* VL53L0X: https://github.com/stm32duino/VL53L0X
+* Proximity_Gesture: https://github.com/stm32duino/Proximity_Gesture
+  
+## Note
+
+The maximum detection distance is influenced by the color of the target and
+the indoor or outdoor situation due to absence or presence of external
+infrared.
+The detection range can be comprise between ~40cm and ~120cm. (see chapter 5 of
+the VL53L0X datasheet).
+If you need an higher accuracy (up to +200cm), you should implement your own
+function.
+
+## Documentation
+
+You can find the source files at  
+https://github.com/stm32duino/X-NUCLEO-53L0A1
+
+The VL53L0X datasheet is available at  
+http://www.st.com/content/st_com/en/products/imaging-and-photonics-solutions/proximity-sensors/vl53l0x.html

--- a/examples/X_NUCLEO_53L0A1_Gesture_DirSwipe/X_NUCLEO_53L0A1_Gesture_DirSwipe.ino
+++ b/examples/X_NUCLEO_53L0A1_Gesture_DirSwipe/X_NUCLEO_53L0A1_Gesture_DirSwipe.ino
@@ -1,0 +1,287 @@
+/**
+ ******************************************************************************
+ * @file    X_NUCLEO_53L0A1_Gesture_DirSwipe.ino
+ * @author  AST
+ * @version V1.0.0
+ * @date    21 April 2017
+ * @brief   Arduino test application for the STMicrolectronics X-NUCLEO-53L0A1
+ *          proximity sensor expansion board based on FlightSense and gesture library.
+ *          This application makes use of C++ classes obtained from the C
+ *          components' drivers.
+ ******************************************************************************
+ * @attention
+ *
+ * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright notice,
+ *      this list of conditions and the following disclaimer in the documentation
+ *      and/or other materials provided with the distribution.
+ *   3. Neither the name of STMicroelectronics nor the names of its contributors
+ *      may be used to endorse or promote products derived from this software
+ *      without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************
+ */
+
+
+/* Includes ------------------------------------------------------------------*/
+#include <Arduino.h>
+#include <Wire.h>
+#include <vl53l0x_x_nucleo_53l0a1_class.h>
+#include <stmpe1600_class.h>
+#include <string.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <assert.h>
+#include <tof_gestures.h>
+#include <tof_gestures_DIRSWIPE_1.h>
+
+#define DEV_I2C Wire
+#define SerialPort Serial
+
+// Components.
+STMPE1600DigiOut *xshutdown_top;
+STMPE1600DigiOut *xshutdown_left;
+STMPE1600DigiOut *xshutdown_right;
+VL53L0X_X_NUCLEO_53L0A1 *sensor_vl53l0x_top;
+VL53L0X_X_NUCLEO_53L0A1 *sensor_vl53l0x_left;
+VL53L0X_X_NUCLEO_53L0A1 *sensor_vl53l0x_right;
+
+// Gesture structure.
+Gesture_DIRSWIPE_1_Data_t gestureDirSwipeData;
+
+// Range values
+uint32_t distance_left, distance_right;
+
+/**
+ *  Setup all sensors for single shot mode
+ */
+void SetupSingleShot(void){
+  int status;
+  uint8_t VhvSettings;
+  uint8_t PhaseCal;
+  uint32_t refSpadCount;
+  uint8_t isApertureSpads;
+
+  status = sensor_vl53l0x_left->StaticInit();
+  if( status ){
+    SerialPort.println("StaticInit left sensor failed");
+  }
+
+  status = sensor_vl53l0x_left->PerformRefCalibration(&VhvSettings, &PhaseCal);
+  if( status ){
+    SerialPort.println("PerformRefCalibration left sensor failed");
+  }
+
+  status = sensor_vl53l0x_left->PerformRefSpadManagement(&refSpadCount, &isApertureSpads);
+  if( status ){
+    SerialPort.println("PerformRefSpadManagement left sensor failed");
+  }
+
+  status = sensor_vl53l0x_left->SetDeviceMode(VL53L0X_DEVICEMODE_SINGLE_RANGING); // Setup in single ranging mode
+  if( status ){
+    SerialPort.println("SetDeviceMode left sensor failed");
+  }
+
+  status = sensor_vl53l0x_left->SetMeasurementTimingBudgetMicroSeconds(20*1000);
+  if( status ){
+    SerialPort.println("SetMeasurementTimingBudgetMicroSeconds left sensor failed");
+  }
+
+  status = sensor_vl53l0x_right->StaticInit();
+  if( status ){
+    SerialPort.println("StaticInit right sensor failed");
+  }
+
+  status = sensor_vl53l0x_right->PerformRefCalibration(&VhvSettings, &PhaseCal);
+  if( status ){
+    SerialPort.println("PerformRefCalibration right sensor failed");
+  }
+
+  status = sensor_vl53l0x_right->PerformRefSpadManagement(&refSpadCount, &isApertureSpads);
+  if( status ){
+    SerialPort.println("PerformRefSpadManagement right sensor failed");
+  }
+
+  status = sensor_vl53l0x_right->SetDeviceMode(VL53L0X_DEVICEMODE_SINGLE_RANGING); // Setup in single ranging mode
+  if( status ){
+    SerialPort.println("SetDeviceMode right sensor failed");
+  }
+
+  status = sensor_vl53l0x_right->SetMeasurementTimingBudgetMicroSeconds(20*1000);
+  if( status ){
+    SerialPort.println("SetMeasurementTimingBudgetMicroSeconds right sensor failed");
+  }
+}
+
+/* Setup ---------------------------------------------------------------------*/
+
+void setup() {
+  int status;
+  // Led.
+  pinMode(13, OUTPUT);
+
+  // Initialize serial for output.
+  SerialPort.begin(115200);
+
+  // Initialize I2C bus.
+  DEV_I2C.begin();
+  DEV_I2C.setClock(400000);
+
+  // Create VL53L0X top component.
+  xshutdown_top = new STMPE1600DigiOut(&DEV_I2C, GPIO_15, (0x42 * 2));
+  sensor_vl53l0x_top = new VL53L0X_X_NUCLEO_53L0A1(&DEV_I2C, xshutdown_top, A2);
+  
+  // Switch off VL53L0X top component.
+  sensor_vl53l0x_top->VL53L0X_Off();
+  
+  // Create (if present) VL53L0X left component.
+  xshutdown_left = new STMPE1600DigiOut(&DEV_I2C, GPIO_14, (0x43 * 2));
+  sensor_vl53l0x_left = new VL53L0X_X_NUCLEO_53L0A1(&DEV_I2C, xshutdown_left, D8);
+  
+  // Switch off (if present) VL53L0X left component.
+  sensor_vl53l0x_left->VL53L0X_Off();
+  
+  // Create (if present) VL53L0X right component.
+  xshutdown_right = new STMPE1600DigiOut(&DEV_I2C, GPIO_15, (0x43 * 2));
+  sensor_vl53l0x_right = new VL53L0X_X_NUCLEO_53L0A1(&DEV_I2C, xshutdown_right, D2);
+  
+  // Switch off (if present) VL53L0X right component.
+  sensor_vl53l0x_right->VL53L0X_Off();
+
+  // Initialize VL53L0X left component.
+  status = sensor_vl53l0x_left->InitSensor(0x12);
+  if(status)
+  {
+    SerialPort.println("Init sensor_vl53l0x_left failed...");
+  }
+
+  // Initialize VL53L0X right component.
+  status = sensor_vl53l0x_right->InitSensor(0x14);
+  if(status)
+  {
+    SerialPort.println("Init sensor_vl53l0x_right failed...");
+  }
+  
+  // Initialize VL6180X gesture library.
+  tof_gestures_initDIRSWIPE_1(400, 0, 1000, &gestureDirSwipeData);
+
+  SetupSingleShot();
+}
+
+
+/* Loop ----------------------------------------------------------------------*/
+
+void loop() {
+  int gesture_code;
+  int status;
+
+  sensor_vl53l0x_left->StartMeasurement();
+  sensor_vl53l0x_right->StartMeasurement();
+
+  int left_done = 0;
+  int right_done = 0;
+  uint8_t NewDataReady=0;
+  VL53L0X_RangingMeasurementData_t pRangingMeasurementData;
+
+  do
+  {
+    if(left_done == 0)
+    {
+      NewDataReady = 0;
+      int status = sensor_vl53l0x_left->GetMeasurementDataReady(&NewDataReady);
+
+      if( status ){
+        SerialPort.println("GetMeasurementDataReady left sensor failed");
+      }
+      
+      if(NewDataReady)
+      {
+        status = sensor_vl53l0x_left->ClearInterruptMask(0);
+        if( status ){
+          SerialPort.println("ClearInterruptMask left sensor failed");
+        }
+
+        status = sensor_vl53l0x_left->GetRangingMeasurementData(&pRangingMeasurementData);
+        if( status ){
+          SerialPort.println("GetRangingMeasurementData left sensor failed");
+        }
+
+        if (pRangingMeasurementData.RangeStatus == 0) {
+          // we have a valid range.
+          distance_left = pRangingMeasurementData.RangeMilliMeter;
+        }else {
+          distance_left = 1200;
+        }
+        
+        left_done = 1;
+      }
+    }
+    
+    if(right_done == 0)
+    {
+      NewDataReady = 0;
+      int status = sensor_vl53l0x_right->GetMeasurementDataReady(&NewDataReady);
+
+      if( status ){
+        SerialPort.println("GetMeasurementDataReady right sensor failed");
+      }
+      
+      if(NewDataReady)
+      {
+        status = sensor_vl53l0x_right->ClearInterruptMask(0);
+        if( status ){
+          SerialPort.println("ClearInterruptMask right sensor failed");
+        }
+
+        status = sensor_vl53l0x_right->GetRangingMeasurementData(&pRangingMeasurementData);
+        if( status ){
+          SerialPort.println("GetRangingMeasurementData right sensor failed");
+        }
+
+        if (pRangingMeasurementData.RangeStatus == 0) {
+          // we have a valid range.
+          distance_right = pRangingMeasurementData.RangeMilliMeter;
+        }else {
+          distance_right = 1200;
+        }
+        
+        right_done = 1;
+      }
+    }
+  }while(left_done == 0 || right_done == 0);
+
+  // Launch gesture detection algorithm.
+  gesture_code = tof_gestures_detectDIRSWIPE_1(distance_left, distance_right, &gestureDirSwipeData);
+
+  // Check the result of the gesture detection algorithm.
+  switch(gesture_code)
+  {
+    case GESTURES_SWIPE_LEFT_RIGHT:
+      SerialPort.println("From LEFT to RIGHT --->");
+      break;
+    case GESTURES_SWIPE_RIGHT_LEFT:
+      SerialPort.println("From RIGHT to LEFT <---");
+      break;
+    default:
+      // Do nothing
+      break;
+  }
+}
+

--- a/examples/X_NUCLEO_53L0A1_Gesture_Swipe1/X_NUCLEO_53L0A1_Gesture_Swipe1.ino
+++ b/examples/X_NUCLEO_53L0A1_Gesture_Swipe1/X_NUCLEO_53L0A1_Gesture_Swipe1.ino
@@ -1,0 +1,218 @@
+/**
+ ******************************************************************************
+ * @file    X_NUCLEO_53L0A1_Gesture_Swipe1.ino
+ * @author  AST
+ * @version V1.0.0
+ * @date    21 April 2017
+ * @brief   Arduino test application for the STMicrolectronics X-NUCLEO-53L0A1
+ *          proximity sensor expansion board based on FlightSense and gesture library.
+ *          This application makes use of C++ classes obtained from the C
+ *          components' drivers.
+ ******************************************************************************
+ * @attention
+ *
+ * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright notice,
+ *      this list of conditions and the following disclaimer in the documentation
+ *      and/or other materials provided with the distribution.
+ *   3. Neither the name of STMicroelectronics nor the names of its contributors
+ *      may be used to endorse or promote products derived from this software
+ *      without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************
+ */
+
+
+/* Includes ------------------------------------------------------------------*/
+#include <Arduino.h>
+#include <Wire.h>
+#include <vl53l0x_x_nucleo_53l0a1_class.h>
+#include <stmpe1600_class.h>
+#include <string.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <assert.h>
+#include <tof_gestures.h>
+#include <tof_gestures_SWIPE_1.h>
+
+#define DEV_I2C Wire
+#define SerialPort Serial
+
+// Components.
+STMPE1600DigiOut *xshutdown_top;
+STMPE1600DigiOut *xshutdown_left;
+STMPE1600DigiOut *xshutdown_right;
+VL53L0X_X_NUCLEO_53L0A1 *sensor_vl53l0x_top;
+VL53L0X_X_NUCLEO_53L0A1 *sensor_vl53l0x_left;
+VL53L0X_X_NUCLEO_53L0A1 *sensor_vl53l0x_right;
+
+// Gesture structure.
+Gesture_SWIPE_1_Data_t gestureSwipeData;
+
+// Range value
+uint32_t distance_top;
+
+/**
+ *  Setup all sensors for single shot mode
+ */
+void SetupSingleShot(void){
+  int status;
+  uint8_t VhvSettings;
+  uint8_t PhaseCal;
+  uint32_t refSpadCount;
+  uint8_t isApertureSpads;
+
+  status = sensor_vl53l0x_top->StaticInit();
+  if( status ){
+    SerialPort.println("StaticInit top sensor failed");
+  }
+
+  status = sensor_vl53l0x_top->PerformRefCalibration(&VhvSettings, &PhaseCal);
+  if( status ){
+    SerialPort.println("PerformRefCalibration top sensor failed");
+  }
+
+  status = sensor_vl53l0x_top->PerformRefSpadManagement(&refSpadCount, &isApertureSpads);
+  if( status ){
+    SerialPort.println("PerformRefSpadManagement top sensor failed");
+  }
+
+  status = sensor_vl53l0x_top->SetDeviceMode(VL53L0X_DEVICEMODE_SINGLE_RANGING); // Setup in single ranging mode
+  if( status ){
+    SerialPort.println("SetDeviceMode top sensor failed");
+  }
+
+  status = sensor_vl53l0x_top->SetMeasurementTimingBudgetMicroSeconds(20*1000);
+  if( status ){
+    SerialPort.println("SetMeasurementTimingBudgetMicroSeconds top sensor failed");
+  }
+}
+
+/* Setup ---------------------------------------------------------------------*/
+
+void setup() {
+  int status;
+  // Led.
+  pinMode(13, OUTPUT);
+
+  // Initialize serial for output.
+  SerialPort.begin(115200);
+
+  // Initialize I2C bus.
+  DEV_I2C.begin();
+
+  // Create VL53L0X top component.
+  xshutdown_top = new STMPE1600DigiOut(&DEV_I2C, GPIO_15, (0x42 * 2));
+  sensor_vl53l0x_top = new VL53L0X_X_NUCLEO_53L0A1(&DEV_I2C, xshutdown_top, A2);
+  
+  // Switch off VL53L0X top component.
+  sensor_vl53l0x_top->VL53L0X_Off();
+  
+  // Create (if present) VL53L0X left component.
+  xshutdown_left = new STMPE1600DigiOut(&DEV_I2C, GPIO_14, (0x43 * 2));
+  sensor_vl53l0x_left = new VL53L0X_X_NUCLEO_53L0A1(&DEV_I2C, xshutdown_left, D8);
+  
+  // Switch off (if present) VL53L0X left component.
+  sensor_vl53l0x_left->VL53L0X_Off();
+  
+  // Create (if present) VL53L0X right component.
+  xshutdown_right = new STMPE1600DigiOut(&DEV_I2C, GPIO_15, (0x43 * 2));
+  sensor_vl53l0x_right = new VL53L0X_X_NUCLEO_53L0A1(&DEV_I2C, xshutdown_right, D2);
+  
+  // Switch off (if present) VL53L0X right component.
+  sensor_vl53l0x_right->VL53L0X_Off();
+  
+  // Initialize VL53L0X top component.
+  status = sensor_vl53l0x_top->InitSensor(0x10);
+  if(status)
+  {
+    SerialPort.println("Init sensor_vl53l0x_top failed...");
+  }
+  
+  // Initialize VL6180X gesture library.
+  tof_gestures_initSWIPE_1(&gestureSwipeData);
+
+  SetupSingleShot();
+}
+
+
+/* Loop ----------------------------------------------------------------------*/
+
+void loop() {
+  int gesture_code;
+  int status;
+  
+  sensor_vl53l0x_top->StartMeasurement();
+  
+  int top_done = 0;
+  uint8_t NewDataReady=0;
+  VL53L0X_RangingMeasurementData_t pRangingMeasurementData;
+
+  do
+  {
+    if(top_done == 0)
+    {
+      NewDataReady = 0;
+      int status = sensor_vl53l0x_top->GetMeasurementDataReady(&NewDataReady);
+
+      if( status ){
+        SerialPort.println("GetMeasurementDataReady top sensor failed");
+      }
+      
+      if(NewDataReady)
+      {
+        status = sensor_vl53l0x_top->ClearInterruptMask(0);
+        if( status ){
+          SerialPort.println("ClearInterruptMask top sensor failed");
+        }
+
+        status = sensor_vl53l0x_top->GetRangingMeasurementData(&pRangingMeasurementData);
+        if( status ){
+          SerialPort.println("GetRangingMeasurementData top sensor failed");
+        }
+
+        if (pRangingMeasurementData.RangeStatus == 0) {
+          // we have a valid range.
+          distance_top = pRangingMeasurementData.RangeMilliMeter;
+        }else {
+          distance_top = 1200;
+        }
+        
+        top_done = 1;
+      }
+    }
+  }while(top_done == 0);
+  
+  // Launch gesture detection algorithm.
+  gesture_code = tof_gestures_detectSWIPE_1(distance_top, &gestureSwipeData);
+
+  // Check the result of the gesture detection algorithm.
+  switch(gesture_code)
+  {
+    case GESTURES_SINGLE_SWIPE:
+      SerialPort.println("GESTURES_SINGLE_SWIPE DETECTED!!!");
+      break;
+    default:
+      // Do nothing
+      break;
+  }
+}
+
+

--- a/examples/X_NUCLEO_53L0A1_Gesture_Tap1/X_NUCLEO_53L0A1_Gesture_Tap1.ino
+++ b/examples/X_NUCLEO_53L0A1_Gesture_Tap1/X_NUCLEO_53L0A1_Gesture_Tap1.ino
@@ -1,0 +1,217 @@
+/**
+ ******************************************************************************
+ * @file    X_NUCLEO_53L0A1_Gesture_Tap1.ino
+ * @author  AST
+ * @version V1.0.0
+ * @date    21 April 2017
+ * @brief   Arduino test application for the STMicrolectronics X-NUCLEO-53L0A1
+ *          proximity sensor expansion board based on FlightSense and gesture library.
+ *          This application makes use of C++ classes obtained from the C
+ *          components' drivers.
+ ******************************************************************************
+ * @attention
+ *
+ * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright notice,
+ *      this list of conditions and the following disclaimer in the documentation
+ *      and/or other materials provided with the distribution.
+ *   3. Neither the name of STMicroelectronics nor the names of its contributors
+ *      may be used to endorse or promote products derived from this software
+ *      without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************
+ */
+
+
+/* Includes ------------------------------------------------------------------*/
+#include <Arduino.h>
+#include <Wire.h>
+#include <vl53l0x_x_nucleo_53l0a1_class.h>
+#include <stmpe1600_class.h>
+#include <string.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <assert.h>
+#include <tof_gestures.h>
+#include <tof_gestures_TAP_1.h>
+
+#define DEV_I2C Wire
+#define SerialPort Serial
+
+// Components.
+STMPE1600DigiOut *xshutdown_top;
+STMPE1600DigiOut *xshutdown_left;
+STMPE1600DigiOut *xshutdown_right;
+VL53L0X_X_NUCLEO_53L0A1 *sensor_vl53l0x_top;
+VL53L0X_X_NUCLEO_53L0A1 *sensor_vl53l0x_left;
+VL53L0X_X_NUCLEO_53L0A1 *sensor_vl53l0x_right;
+
+// Gesture structure.
+Gesture_TAP_1_Data_t gestureTapData;
+
+// Range value
+uint32_t distance_top;
+
+/**
+ *  Setup all sensors for single shot mode
+ */
+void SetupSingleShot(void){
+  int status;
+  uint8_t VhvSettings;
+  uint8_t PhaseCal;
+  uint32_t refSpadCount;
+  uint8_t isApertureSpads;
+
+  status = sensor_vl53l0x_top->StaticInit();
+  if( status ){
+    SerialPort.println("StaticInit top sensor failed");
+  }
+
+  status = sensor_vl53l0x_top->PerformRefCalibration(&VhvSettings, &PhaseCal);
+  if( status ){
+    SerialPort.println("PerformRefCalibration top sensor failed");
+  }
+
+  status = sensor_vl53l0x_top->PerformRefSpadManagement(&refSpadCount, &isApertureSpads);
+  if( status ){
+    SerialPort.println("PerformRefSpadManagement top sensor failed");
+  }
+
+  status = sensor_vl53l0x_top->SetDeviceMode(VL53L0X_DEVICEMODE_SINGLE_RANGING); // Setup in single ranging mode
+  if( status ){
+    SerialPort.println("SetDeviceMode top sensor failed");
+  }
+
+  status = sensor_vl53l0x_top->SetMeasurementTimingBudgetMicroSeconds(20*1000);
+  if( status ){
+    SerialPort.println("SetMeasurementTimingBudgetMicroSeconds top sensor failed");
+  }
+}
+
+/* Setup ---------------------------------------------------------------------*/
+
+void setup() {
+  int status;
+  // Led.
+  pinMode(13, OUTPUT);
+
+  // Initialize serial for output.
+  SerialPort.begin(115200);
+
+  // Initialize I2C bus.
+  DEV_I2C.begin();
+
+  // Create VL53L0X top component.
+  xshutdown_top = new STMPE1600DigiOut(&DEV_I2C, GPIO_15, (0x42 * 2));
+  sensor_vl53l0x_top = new VL53L0X_X_NUCLEO_53L0A1(&DEV_I2C, xshutdown_top, A2);
+  
+  // Switch off VL53L0X top component.
+  sensor_vl53l0x_top->VL53L0X_Off();
+  
+  // Create (if present) VL53L0X left component.
+  xshutdown_left = new STMPE1600DigiOut(&DEV_I2C, GPIO_14, (0x43 * 2));
+  sensor_vl53l0x_left = new VL53L0X_X_NUCLEO_53L0A1(&DEV_I2C, xshutdown_left, D8);
+  
+  // Switch off (if present) VL53L0X left component.
+  sensor_vl53l0x_left->VL53L0X_Off();
+  
+  // Create (if present) VL53L0X right component.
+  xshutdown_right = new STMPE1600DigiOut(&DEV_I2C, GPIO_15, (0x43 * 2));
+  sensor_vl53l0x_right = new VL53L0X_X_NUCLEO_53L0A1(&DEV_I2C, xshutdown_right, D2);
+  
+  // Switch off (if present) VL53L0X right component.
+  sensor_vl53l0x_right->VL53L0X_Off();
+  
+  // Initialize VL53L0X top component.
+  status = sensor_vl53l0x_top->InitSensor(0x10);
+  if(status)
+  {
+    SerialPort.println("Init sensor_vl53l0x_top failed...");
+  }
+  
+  // Initialize VL6180X gesture library.
+  tof_gestures_initTAP_1(&gestureTapData);
+
+  SetupSingleShot();
+}
+
+
+/* Loop ----------------------------------------------------------------------*/
+
+void loop() {
+  int gesture_code;
+  int status;
+  
+  sensor_vl53l0x_top->StartMeasurement();
+  
+  int top_done = 0;
+  uint8_t NewDataReady=0;
+  VL53L0X_RangingMeasurementData_t pRangingMeasurementData;
+
+  do
+  {
+    if(top_done == 0)
+    {
+      NewDataReady = 0;
+      int status = sensor_vl53l0x_top->GetMeasurementDataReady(&NewDataReady);
+
+      if( status ){
+        SerialPort.println("GetMeasurementDataReady top sensor failed");
+      }
+      
+      if(NewDataReady)
+      {
+        status = sensor_vl53l0x_top->ClearInterruptMask(0);
+        if( status ){
+          SerialPort.println("ClearInterruptMask top sensor failed");
+        }
+
+        status = sensor_vl53l0x_top->GetRangingMeasurementData(&pRangingMeasurementData);
+        if( status ){
+          SerialPort.println("GetRangingMeasurementData top sensor failed");
+        }
+
+        if (pRangingMeasurementData.RangeStatus == 0) {
+          // we have a valid range.
+          distance_top = pRangingMeasurementData.RangeMilliMeter;
+        }else {
+          distance_top = 1200;
+        }
+        
+        top_done = 1;
+      }
+    }
+  }while(top_done == 0);
+  
+  // Launch gesture detection algorithm.
+  gesture_code = tof_gestures_detectTAP_1(distance_top, &gestureTapData);
+
+  // Check the result of the gesture detection algorithm.
+  switch(gesture_code)
+  {
+    case GESTURES_SINGLE_TAP:
+      SerialPort.println("GESTURES_SINGLE_TAP DETECTED!!!");
+      break;
+    default:
+      // Do nothing
+      break;
+  }
+}
+

--- a/examples/X_NUCLEO_53L0A1_HelloWorld/X_NUCLEO_53L0A1_HelloWorld.ino
+++ b/examples/X_NUCLEO_53L0A1_HelloWorld/X_NUCLEO_53L0A1_HelloWorld.ino
@@ -1,0 +1,162 @@
+/**
+ ******************************************************************************
+ * @file    X_NUCLEO_53L0A1_HelloWorld.ino
+ * @author  AST
+ * @version V1.0.0
+ * @date    24 March 2016
+ * @brief   Arduino test application for the STMicrolectronics X-NUCLEO-53L0A1
+ *          proximity sensor expansion board based on FlightSense.
+ *          This application makes use of C++ classes obtained from the C
+ *          components' drivers.
+ ******************************************************************************
+ * @attention
+ *
+ * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright notice,
+ *      this list of conditions and the following disclaimer in the documentation
+ *      and/or other materials provided with the distribution.
+ *   3. Neither the name of STMicroelectronics nor the names of its contributors
+ *      may be used to endorse or promote products derived from this software
+ *      without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************
+ */
+
+
+/* Includes ------------------------------------------------------------------*/
+#include <Arduino.h>
+#include <Wire.h>
+#include <vl53l0x_x_nucleo_53l0a1_class.h>
+#include <stmpe1600_class.h>
+#include <string.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <assert.h>
+
+#define DEV_I2C Wire
+#define SerialPort Serial
+
+// Components.
+STMPE1600DigiOut *xshutdown_top;
+STMPE1600DigiOut *xshutdown_left;
+STMPE1600DigiOut *xshutdown_right;
+VL53L0X_X_NUCLEO_53L0A1 *sensor_vl53l0x_top;
+VL53L0X_X_NUCLEO_53L0A1 *sensor_vl53l0x_left;
+VL53L0X_X_NUCLEO_53L0A1 *sensor_vl53l0x_right;
+
+/* Setup ---------------------------------------------------------------------*/
+
+void setup() {
+  int status;
+  // Led.
+  pinMode(13, OUTPUT);
+
+  // Initialize serial for output.
+  SerialPort.begin(115200);
+
+  // Initialize I2C bus.
+  DEV_I2C.begin();
+
+  // Create VL53L0X top component.
+  xshutdown_top = new STMPE1600DigiOut(&DEV_I2C, GPIO_15, (0x42 * 2));
+  sensor_vl53l0x_top = new VL53L0X_X_NUCLEO_53L0A1(&DEV_I2C, xshutdown_top, A2);
+  
+  // Switch off VL53L0X top component.
+  sensor_vl53l0x_top->VL53L0X_Off();
+  
+  // Create (if present) VL53L0X left component.
+  xshutdown_left = new STMPE1600DigiOut(&DEV_I2C, GPIO_14, (0x43 * 2));
+  sensor_vl53l0x_left = new VL53L0X_X_NUCLEO_53L0A1(&DEV_I2C, xshutdown_left, D8);
+  
+  // Switch off (if present) VL53L0X left component.
+  sensor_vl53l0x_left->VL53L0X_Off();
+  
+  // Create (if present) VL53L0X right component.
+  xshutdown_right = new STMPE1600DigiOut(&DEV_I2C, GPIO_15, (0x43 * 2));
+  sensor_vl53l0x_right = new VL53L0X_X_NUCLEO_53L0A1(&DEV_I2C, xshutdown_right, D2);
+  
+  // Switch off (if present) VL53L0X right component.
+  sensor_vl53l0x_right->VL53L0X_Off();
+  
+  // Initialize VL53L0X top component.
+  status = sensor_vl53l0x_top->InitSensor(0x10);
+  if(status)
+  {
+    SerialPort.println("Init sensor_vl53l0x_top failed...");
+  }
+
+  // Initialize VL53L0X left component.
+  status = sensor_vl53l0x_left->InitSensor(0x12);
+  if(status)
+  {
+    SerialPort.println("Init sensor_vl53l0x_left failed...");
+  }
+
+  // Initialize VL53L0X right component.
+  status = sensor_vl53l0x_right->InitSensor(0x14);
+  if(status)
+  {
+    SerialPort.println("Init sensor_vl53l0x_right failed...");
+  }
+}
+
+
+/* Loop ----------------------------------------------------------------------*/
+
+void loop() {
+  // Led blinking.
+  digitalWrite(13, HIGH);
+  delay(100);
+  digitalWrite(13, LOW);
+  
+  // Read Range.
+  uint32_t distance;
+  int status;
+  status = sensor_vl53l0x_top->GetDistance(&distance);
+
+  if (status == VL53L0X_ERROR_NONE)
+  {
+    // Output data.
+    char report[64];
+    snprintf(report, sizeof(report), "| Distance top [mm]: %ld |", distance);
+    SerialPort.println(report);
+  }
+
+  status = sensor_vl53l0x_left->GetDistance(&distance);
+
+  if (status == VL53L0X_ERROR_NONE)
+  {
+    // Output data.
+    char report[64];
+    snprintf(report, sizeof(report), "| Distance left [mm]: %ld |", distance);
+    SerialPort.println(report);
+  }
+
+  status = sensor_vl53l0x_right->GetDistance(&distance);
+
+  if (status == VL53L0X_ERROR_NONE)
+  {
+    // Output data.
+    char report[64];
+    snprintf(report, sizeof(report), "| Distance right [mm]: %ld |", distance);
+    SerialPort.println(report);
+  }
+}
+

--- a/keywords.txt
+++ b/keywords.txt
@@ -1,0 +1,18 @@
+#######################################
+# Syntax Coloring Map For x-nucleo-53l0a1
+#######################################
+
+#######################################
+# Datatypes (KEYWORD1)
+#######################################
+
+STMPE1600DigiOut KEYWORD1
+VL53L0X_X_NUCLEO_53L0A1 KEYWORD1
+
+#######################################
+# Methods and Functions (KEYWORD2)
+#######################################
+
+VL53L0X_Off KEYWORD2
+VL53L0X_On KEYWORD2
+write KEYWORD2

--- a/library.properties
+++ b/library.properties
@@ -1,0 +1,9 @@
+name=STM32duino X-NUCLEO-53L0A1
+version=1.0.0
+author=AST
+maintainer=stm32duino
+sentence=Allows controlling the VL53L0X sensors on board of X-NUCLEO-53L0A1
+paragraph=This library provides simple measure distance in mm, single swipe gesture detection, directional (left/right) swipe gesture detection and single tap gesture detection.
+category=Device Control
+url=https://github.com/stm32duino/X-NUCLEO-53L0A1
+architectures=stm32

--- a/src/stmpe1600_class.h
+++ b/src/stmpe1600_class.h
@@ -1,0 +1,170 @@
+/**
+ ******************************************************************************
+ * @file    stmpe1600_class.h
+ * @author  AST / EST
+ * @version V0.0.1
+ * @date    14-April-2015
+ * @brief   Header file for component stmpe1600
+ ******************************************************************************
+ * @attention
+ *
+ * <h2><center>&copy; COPYRIGHT(c) 2015 STMicroelectronics</center></h2>
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright notice,
+ *      this list of conditions and the following disclaimer in the documentation
+ *      and/or other materials provided with the distribution.
+ *   3. Neither the name of STMicroelectronics nor the names of its contributors
+ *      may be used to endorse or promote products derived from this software
+ *       without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************
+*/
+#ifndef     __STMPE1600_CLASS
+#define     __STMPE1600_CLASS
+/* Includes ------------------------------------------------------------------*/
+#include <Wire.h>
+
+#define STMPE1600_DEF_DEVICE_ADDRESS  (uint8_t)0x42*2   
+#define STMPE1600_DEF_DIGIOUT_LVL      1
+
+/**  STMPE1600 registr map **/
+#define ChipID_0_7      (uint8_t)0x00
+#define ChipID_8_15     (uint8_t)0x01
+#define VersionId       (uint8_t)0x02
+#define SYS_CTRL        (uint8_t)0x03
+#define IEGPIOR_0_7     (uint8_t)0x08
+#define IEGPIOR_8_15    (uint8_t)0x09
+#define ISGPIOR_0_7	    (uint8_t)0x0A
+#define ISGPIOR_8_15    (uint8_t)0x0B
+#define GPMR_0_7        (uint8_t)0x10
+#define GPMR_8_15       (uint8_t)0x11
+#define GPSR_0_7        (uint8_t)0x12
+#define GPSR_8_15       (uint8_t)0x13
+#define GPDR_0_7        (uint8_t)0x14
+#define GPDR_8_15       (uint8_t)0x15
+#define GPIR_0_7        (uint8_t)0x16
+#define GPIR_8_15	    (uint8_t)0x17
+
+#define SOFT_RESET      (uint8_t)0x80
+
+typedef enum {
+  // GPIO Expander pin names
+  GPIO_0=0,
+  GPIO_1,
+  GPIO_2,
+  GPIO_3,            
+  GPIO_4,
+  GPIO_5,
+  GPIO_6,
+  GPIO_7,            
+  GPIO_8,
+  GPIO_9,
+  GPIO_10,
+  GPIO_11,            
+  GPIO_12,
+  GPIO_13,
+  GPIO_14,
+  GPIO_15,
+  NOT_CON
+} ExpGpioPinName;   
+
+typedef enum {
+    EXP_GPIO_INPUT = 0,
+    EXP_GPIO_OUTPUT,
+    EXP_GPIO_NOT_CONNECTED
+} ExpGpioPinDirection;
+
+/* Classes -------------------------------------------------------------------*/
+/** Class representing a single stmpe1600 GPIO expander output pin
+ */
+class STMPE1600DigiOut {
+	
+ public: 
+    /** Constructor
+     * @param[in] &i2c device I2C to be used for communication
+     * @param[in] outpinname the desired out pin name to be created
+     * @param[in] DevAddr the stmpe1600 I2C device addres (deft STMPE1600_DEF_DEVICE_ADDRESS)
+     * @param[in] lvl the default ot pin level  
+     */ 
+    STMPE1600DigiOut (TwoWire *i2c, ExpGpioPinName outpinname, uint8_t DevAddr=STMPE1600_DEF_DEVICE_ADDRESS, bool lvl=STMPE1600_DEF_DIGIOUT_LVL): dev_i2c(i2c), expdevaddr(DevAddr), exppinname(outpinname) 
+    {
+       uint8_t data[2];				
+       if (exppinname == NOT_CON) return;
+       /* set the exppinname as output */
+       STMPE1600DigiOut_I2CRead(data, expdevaddr, GPDR_0_7, 1);
+       STMPE1600DigiOut_I2CRead(&data[1], expdevaddr, GPDR_8_15, 1);			
+       *(uint16_t*)data = *(uint16_t*)data | (1<<(uint16_t)exppinname);  // set gpio as out 			
+       STMPE1600DigiOut_I2CWrite(data, expdevaddr, GPDR_0_7, 1);
+       STMPE1600DigiOut_I2CWrite(&data[1], expdevaddr, GPDR_8_15, 1);			
+       write(lvl);
+    }   
+
+	/**
+	 * @brief       Write on the out pin
+	 * @param[in]   lvl level to write
+	 * @return      0 on Success
+	 */			
+    void write (int lvl) 
+    {
+       uint8_t data[2];			
+       if (exppinname == NOT_CON) return;			
+       /* set the exppinname state to lvl */
+       STMPE1600DigiOut_I2CRead(data, expdevaddr, GPSR_0_7, 2);
+       *(uint16_t*)data = *(uint16_t*)data & (uint16_t)(~(1<<(uint16_t)exppinname));  // set pin mask 			
+       if (lvl) *(uint16_t*)data = *(uint16_t*)data | (uint16_t)(1<<(uint16_t)exppinname);
+       STMPE1600DigiOut_I2CWrite(data, expdevaddr, GPSR_0_7, 2);
+    }
+		
+ private:
+    TwoWire *dev_i2c; 
+    uint8_t expdevaddr;
+    ExpGpioPinName exppinname;
+
+    int STMPE1600DigiOut_I2CWrite(uint8_t* pBuffer, uint8_t DeviceAddr, uint8_t RegisterAddr, uint16_t NumByteToWrite)
+    {
+      dev_i2c->beginTransmission(((uint8_t)(((DeviceAddr) >> 1) & 0x7F)));
+  
+      dev_i2c->write(RegisterAddr);
+      for (int i = 0 ; i < NumByteToWrite ; i++)
+        dev_i2c->write(pBuffer[i]);
+  
+      dev_i2c->endTransmission(true);
+  
+      return 0;
+    }
+
+    int STMPE1600DigiOut_I2CRead(uint8_t* pBuffer, uint8_t DeviceAddr, uint8_t RegisterAddr, uint16_t NumByteToRead)
+    {
+      dev_i2c->beginTransmission(((uint8_t)(((DeviceAddr) >> 1) & 0x7F)));
+      dev_i2c->write(RegisterAddr);
+      dev_i2c->endTransmission(false);
+  
+      dev_i2c->requestFrom(((uint8_t)(((DeviceAddr) >> 1) & 0x7F)), (byte) NumByteToRead);
+
+      int i=0;
+      while (dev_i2c->available())
+      {
+        pBuffer[i] = dev_i2c->read();
+        i++;
+      }
+  
+      return 0;
+    }
+};
+
+#endif // __STMPE1600_CLASS

--- a/src/vl53l0x_x_nucleo_53l0a1_class.h
+++ b/src/vl53l0x_x_nucleo_53l0a1_class.h
@@ -1,0 +1,103 @@
+/**
+ ******************************************************************************
+ * @file    vl53l0x_x_nucleo_53l0a1_class.h
+ * @author  AST / EST
+ * @version V0.0.1
+ * @date    14-November-2017
+ * @brief   Header file for component VL53L0X
+ ******************************************************************************
+ * @attention
+ *
+ * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright notice,
+ *      this list of conditions and the following disclaimer in the documentation
+ *      and/or other materials provided with the distribution.
+ *   3. Neither the name of STMicroelectronics nor the names of its contributors
+ *      may be used to endorse or promote products derived from this software
+ *       without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************
+*/
+
+#ifndef __VL53L0X_X_NUCLEO_53L0A1_CLASS_H
+#define __VL53L0X_X_NUCLEO_53L0A1_CLASS_H
+
+
+/* Includes ------------------------------------------------------------------*/
+#include "Arduino.h"
+#include "vl53l0x_class.h"
+#include "stmpe1600_class.h"
+
+
+/* Classes -------------------------------------------------------------------*/
+/** Class representing a VL53L0 sensor component
+ */
+class VL53L0X_X_NUCLEO_53L0A1 : public VL53L0X
+{
+ public:
+    /** Constructor (STMPE1600DigiOut)
+     * @param[in] i2c device I2C to be used for communication
+     * @param[in] &pin Gpio Expander STMPE1600DigiOut pin to be used as component GPIO_0 CE
+     * @param[in] pin_gpio1 pin Mbed InterruptIn PinName to be used as component GPIO_1 INT
+     * @param[in] device address, 0x29 by default  
+     */		
+    VL53L0X_X_NUCLEO_53L0A1(TwoWire *i2c, STMPE1600DigiOut *pin, int pin_gpio1, uint8_t DevAddr=VL53L0x_DEFAULT_DEVICE_ADDRESS) : VL53L0X(i2c, -1, pin_gpio1, DevAddr)
+    {
+       expgpio0 = pin;
+    }  	 
+    
+   /** Destructor
+    */
+    virtual ~VL53L0X_X_NUCLEO_53L0A1(){}     
+    /* warning: VL53L0X_X_NUCLEO_53L0A1 class inherits from GenericSensor, RangeSensor and LightSensor, that haven`t a destructor.
+       The warning should request to introduce a virtual destructor to make sure to delete the object */
+
+	/*** Interface Methods ***/	
+	/*** High level API ***/		
+	/**
+	 * @brief       PowerOn the sensor
+	 * @return      void
+	 */		
+    /* turns on the sensor */		 
+    void VL53L0X_On(void)
+    { 
+       expgpio0->write(1);
+       delay(10);    
+    } 
+
+	/**
+	 * @brief       PowerOff the sensor
+	 * @return      void
+	 */		
+    /* turns off the sensor */
+    void VL53L0X_Off(void) 
+    { 
+       expgpio0->write(0);
+       delay(10);    
+    }
+	
+ protected:		
+    /* GPIO expander */
+    STMPE1600DigiOut *expgpio0;  
+};
+
+
+#endif /* __VL53L0X_X_NUCLEO_53L0A1_CLASS_H */
+
+


### PR DESCRIPTION
This package supports the X-NUCLEO-53L0A1 shield. The main class derives from VL53L0X class adding also a basic support to the gpio expander. The display management is not implemented yet. 